### PR TITLE
Eager load associations

### DIFF
--- a/app/controllers/spina/conferences/conferences_controller.rb
+++ b/app/controllers/spina/conferences/conferences_controller.rb
@@ -7,14 +7,17 @@ module Spina
       include Eventable
 
       def index
-        @conferences = Conference.sorted
+        @conferences = Conference.includes(:institution).sorted
         respond_to do |format|
           format.ics { render body: make_calendar(@conferences, name: current_account.name).to_ical }
         end
       end
 
       def show
-        @conference = Conference.find(params[:id])
+        @conference = Conference.includes(:institution,
+                                          presentations: [:presentation_type,
+                                                          presenters: :institution,
+                                                          room_use: [room_possession: :room]]).find(params[:id])
         respond_to do |format|
           format.ics do
             render body: make_calendar(@conference, @conference.presentations, name: @conference.name).to_ical

--- a/app/controllers/spina/conferences/presentations_controller.rb
+++ b/app/controllers/spina/conferences/presentations_controller.rb
@@ -7,7 +7,9 @@ module Spina
       include Eventable
 
       def show
-        @presentation = Presentation.find(params[:id])
+        @presentation = Presentation.includes(:presentation_type,
+                                              presenters: :institution,
+                                              room_use: [room_possession: :room]).find(params[:id])
         respond_to { |format| format.ics { render body: make_calendar(@presentation).to_ical } }
       end
     end


### PR DESCRIPTION
Skylight shows that we should eager load a number of associations when showing calendar events to optimise database performance. This PR does this.